### PR TITLE
Require DataMigration model when running migrator

### DIFF
--- a/lib/seed_migration/migrator.rb
+++ b/lib/seed_migration/migrator.rb
@@ -1,4 +1,5 @@
 require 'pathname'
+require 'seed_migration/data_migration'
 
 module SeedMigration
   class Migrator


### PR DESCRIPTION
This resolves an issue we experienced where trying to seed in production
would fail to find the DataMigration model. After this fix the following
command works:

  $ RAILS_ENV=production bundle exec rake seed:migrate
