### PR TITLE
Explicitly require gem models

### DIFF
--- a/lib/seed_migration/engine.rb
+++ b/lib/seed_migration/engine.rb
@@ -33,5 +33,6 @@ module SeedMigration
       g.helper false
     end
 
+    Dir["#{config.root}/app/models/**/*.rb"].each { |file| require file }
   end
 end


### PR DESCRIPTION
Fixes issue https://github.com/harrystech/seed_migration/issues/12, where rails `config.threadsafe!` turns off dependency loading ([see here](https://github.com/rails/rails/blob/02e4d7ffd4b96d13efd0c5ebba703606fc2e6414/railties/lib/rails/application/configuration.rb#L102)).
