### PR TITLE
Adds support for custom "migrations_path"

### DIFF
--- a/lib/generators/seed_migration/seed_migration_generator.rb
+++ b/lib/generators/seed_migration/seed_migration_generator.rb
@@ -10,7 +10,7 @@ module SeedMigration
       argument :timestamp, :type => :string, :required => false, :default => Time.now.utc.strftime("%Y%m%d%H%M%S")
 
       def create_seed_migration_file
-        path = SeedMigration::Migrator::DATA_MIGRATION_DIRECTORY
+        path = SeedMigration::Migrator.data_migration_directory
         create_file path.join("#{timestamp}_#{file_name.gsub(/([A-Z])/, '_\1').downcase}.rb"), contents
       end
 

--- a/lib/seed_migration/engine.rb
+++ b/lib/seed_migration/engine.rb
@@ -7,11 +7,13 @@ module SeedMigration
     mattr_accessor :migration_table_name
     mattr_accessor :ignore_ids
     mattr_accessor :update_seeds_file
+    mattr_accessor :migrations_path
 
     self.migration_table_name = 'seed_migration_data_migrations' # Hardcoded, evil!
     self.extend_native_migration_task = false
     self.ignore_ids = false
     self.update_seeds_file = true
+    self.migrations_path = 'data'
   end
 
   def self.config(&block)

--- a/lib/seed_migration/migrator.rb
+++ b/lib/seed_migration/migrator.rb
@@ -2,11 +2,14 @@ require 'pathname'
 
 module SeedMigration
   class Migrator
-    DATA_MIGRATION_DIRECTORY = Rails.root.join("db", "data")
     SEEDS_FILE_PATH = Rails.root.join('db', 'seeds.rb')
 
+    def self.data_migration_directory
+      Rails.root.join("db", SeedMigration.migrations_path)
+    end
+
     def self.migration_path(filename)
-      DATA_MIGRATION_DIRECTORY.join(filename).to_s
+      data_migration_directory.join(filename).to_s
     end
 
     def initialize(migration_path)

--- a/spec/lib/migrator_spec.rb
+++ b/spec/lib/migrator_spec.rb
@@ -339,4 +339,32 @@ describe SeedMigration::Migrator do
       end
     end
   end
+
+  describe ".migrations_path" do
+
+    context "with default path" do
+      it 'it should create migrations in db/data' do
+        SeedMigration::Migrator.get_migration_files.each do |f|
+          expect(File.split(File.dirname(f))[1]).to eq("data")
+        end
+      end
+    end
+
+    context "with custom path" do
+      before(:all) do
+        SeedMigration.migrations_path = "foo"
+      end
+
+      after(:all) do
+        SeedMigration.migrations_path = "data"
+      end
+
+      it 'it should create migrations in db/foo' do
+        SeedMigration::Migrator.get_migration_files.each do |f|
+          expect(File.split(File.dirname(f))[1]).to eq("foo")
+        end
+      end
+    end
+
+  end
 end


### PR DESCRIPTION
Hi.

We're have huge project and your gem is lifesaver.

But I've created a little improvement which is very useful for us.

_config/initializers/seed_migration.rb_

``` ruby
SeedMigration.config do |c|
  c.migrations_path = File.join("seed", "development") if Rails.env.development?
  c.migrations_path = File.join("seed", "test")        if Rails.env.test?
  c.migrations_path = File.join("seed", "production")  if Rails.env.production?
end
```

I did this because:
- Tried to avoid "seeding" from schema migrations (this is real pain)
- Incrementally seed data in production
- Don't mess production/dev/test data into one seed

Of course if you need to share your "seed" across multiple environments, you should create something like "seed/shared/<a lot of files>" and include these shared files into real migrations, but I think this is adequate trade off.

Enjoy :smile:
